### PR TITLE
Update mem_file_checker-inl.h

### DIFF
--- a/mem_file_checker-inl.h
+++ b/mem_file_checker-inl.h
@@ -22,6 +22,11 @@
 #ifndef MEM_FILE_CHECKER_INL_H__
 #define MEM_FILE_CHECKER_INL_H__
 
+/* fopen64 missing on OS X */
+#ifdef __APPLE__
+#  define fopen64 fopen
+#endif
+
 #include <stdlib.h>
 #include <stdio.h>
 #include "helper_functions-inl.h"


### PR DESCRIPTION
Define fopen64 on OS X (and fix issue #5)
