### PR TITLE
CXX is an implicitly defined variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,6 @@ DEPS =   ./Makefile \
 #-------------------------------------------------------------------------------
 # g++ and its options
 #-------------------------------------------------------------------------------
-CXX = g++
 CUDALIBFLAG = -L/usr/local/cuda/lib64/ -lcuda -lcudart
 CFLAGS = -O3 -Wall -funroll-loops -fprefetch-loop-arrays -fopenmp -std=c++0x -lm
 ZLIB = -lz


### PR DESCRIPTION
CXX is implicitly defined by Make. Leaving is empty will allow one to either use the default or specify it as an environment variable.
