### PR TITLE
script: fix "megahit: option --num-cpu-threads not recognized"

### DIFF
--- a/megahit
+++ b/megahit
@@ -148,6 +148,7 @@ def parse_opt(argv):
                                      "k-min=",
                                      "k-max=",
                                      "k-step=",
+                                     "num-cpu-threads=",
                                      "min-count=",
                                      "no-mercy",
                                      "no-low-local",


### PR DESCRIPTION
The option --num-cpu-threads appears in the help page of megahit,
but it was missing from the list of options given to
getopt.getopt().