### PR TITLE
Python 2 and 3 compatibility

### DIFF
--- a/megahit
+++ b/megahit
@@ -366,7 +366,7 @@ def delete_temp_files(kmer_k):
         delect_file_if_exist(graph_prefix(kmer_k) + ".rr.pb")
         delect_file_if_exist(graph_prefix(kmer_k) + ".edges.0")
     else:
-        for i in range(0, max(1, opt.num_cpu_threads / 3)):
+        for i in range(0, max(1, int(opt.num_cpu_threads / 3))):
             delect_file_if_exist(graph_prefix(kmer_k) + ".edges." + str(i))
         if opt.no_mercy == 0:
             for i in range(0, opt.num_cpu_threads - 1):

--- a/megahit
+++ b/megahit
@@ -18,6 +18,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------
 
+from __future__ import print_function
+
 import sys
 import getopt
 import subprocess
@@ -168,7 +170,7 @@ def parse_opt(argv):
                                      "keep-tmp-files",
                                      "mem-flag=",
                                      "continue"])
-    except getopt.error, msg:
+    except getopt.error as msg:
         raise Usage(megahit_version_str + '\n' + str(msg))
     if len(opts) == 0:
         raise Usage(megahit_version_str + '\n' + usage_message)
@@ -187,9 +189,9 @@ def parse_opt(argv):
         elif option == "--input-cmd":
             opt.input_cmd = value
         elif option in ("-m", "--memory"):
-            opt.host_mem = long(float(value))
+            opt.host_mem = int(float(value))
         elif option == "--gpu-mem":
-            opt.host_mem = long(float(value))
+            opt.host_mem = int(float(value))
         elif option in ("-l", "--max-read-len"):
             opt.max_read_len = int(value)
         elif option == "--min-contig-len":
@@ -223,7 +225,7 @@ def parse_opt(argv):
             if opt.continue_mode == 0: # avoid check again again again...
                 need_continue = True
         else:
-            print >> sys.stderr, "Invalid option %s", option
+            print("Invalid option %s", option, file=sys.stderr)
             exit(1)
 
     if need_continue:
@@ -232,76 +234,76 @@ def parse_opt(argv):
 def check_opt():
     global opt
     if opt.host_mem <= 0:
-        print >> sys.stderr, "Memory must be greater than 0."
+        print("Memory must be greater than 0.", file=sys.stderr)
         exit(1)
     if opt.cpu_only == 1:
         opt.gpu_mem = 0
     if opt.max_read_len <= 1:
-        print >> sys.stderr, "max_read_len must be greater than 1."
+        print("max_read_len must be greater than 1.", file=sys.stderr)
         exit(1)
     if opt.read_file == "" and opt.input_cmd == "":
-        print >> sys.stderr, "No read_file or input_cmd."
+        print("No read_file or input_cmd.", file=sys.stderr)
         exit(1)
     if opt.read_file != "" and opt.input_cmd != "":
-        print >> sys.stderr, "Both read_file and input_cmd are set. Please use only one of them."
+        print("Both read_file and input_cmd are set. Please use only one of them.", file=sys.stderr)
         exit(1)
     if opt.k_max >= opt.max_read_len:
         opt.k_max = int(opt.max_read_len) / 2 * 2 - 1 
-        print >> sys.stderr, "Constrain maximum read length, k_max is set to be " + str(opt.k_max)
+        print("Constrain maximum read length, k_max is set to be " + str(opt.k_max), file=sys.stderr)
     if opt.k_min < 9:
-        print >> sys.stderr, "k_min should be at least 9."
+        print("k_min should be at least 9.", file=sys.stderr)
         exit(1)
     if opt.k_max > 123:
-        print >> sys.stderr, "k_max cannot exceed 123."
+        print("k_max cannot exceed 123.", file=sys.stderr)
         exit(1)
     if opt.k_max < opt.k_min:
-        print >> sys.stderr, "k_min should be no larger than k_max."
+        print("k_min should be no larger than k_max.", file=sys.stderr)
         exit(1)
     if opt.k_min % 2 == 0 or opt.k_max % 2 == 0:
-        print >> sys.stderr, "k_min and k_max must be odd numbers."
+        print("k_min and k_max must be odd numbers.", file=sys.stderr)
         exit(1)
     if opt.k_step > 28:
-        print >> sys.stderr, "step must be less than 29."
+        print("step must be less than 29.", file=sys.stderr)
         exit(1)
     if opt.k_step % 2 != 0:
-        print >> sys.stderr, "step must be an even number."
+        print("step must be an even number.", file=sys.stderr)
         exit(1)
     if opt.min_count <= 0:
-        print >> sys.stderr, "min_count must be greater than 0."
+        print("min_count must be greater than 0.", file=sys.stderr)
         exit(1)
     if opt.low_local_ratio <= 0 or opt.low_local_ratio > 0.5:
-        print >> sys.stderr, "low_local_ratio should be in (0, 0.5]."
+        print("low_local_ratio should be in (0, 0.5].", file=sys.stderr)
         exit(1)
     if opt.num_cpu_threads > multiprocessing.cpu_count():
-        print >> sys.stderr, "Maximum number of available CPU thread is %d." % multiprocessing.cpu_count();
-        print >> sys.stderr, "Number of thread is reset to the %d." % multiprocessing.cpu_count();
+        print("Maximum number of available CPU thread is %d." % multiprocessing.cpu_count(), file=sys.stderr);
+        print("Number of thread is reset to the %d." % multiprocessing.cpu_count(), file=sys.stderr);
         opt.num_cpu_threads = multiprocessing.cpu_count()
     if opt.num_cpu_threads == 0:
         opt.num_cpu_threads = multiprocessing.cpu_count()
     if opt.num_cpu_threads <= 1:
-        print >> sys.stderr, "num_cpu_threads should be at least 2."
+        print("num_cpu_threads should be at least 2.", file=sys.stderr)
         exit(1)
 
 def write_opt(argv):
     with open(opt.out_dir + "opts.txt", "w") as f:
-        print >> f, "\n".join(argv)
+        print("\n".join(argv), file=f)
 
 def prepare_continue():
     global opt # out_dir is already set
 
     if not os.path.exists(opt.out_dir + "opts.txt"):
-        print >> sys.stderr, "Cannot find " + opt.out_dir + "opts.txt"
-        print >> sys.stderr, "Please check whether the output directory is correctly set by \"-o\""
-        print >> sys.stderr, "Now switching to normal mode."
+        print("Cannot find " + opt.out_dir + "opts.txt", file=sys.stderr)
+        print("Please check whether the output directory is correctly set by \"-o\"", file=sys.stderr)
+        print("Now switching to normal mode.", file=sys.stderr)
         return
 
-    print >> sys.stderr, "Continue mode activated. Ignore all options other than -o/--out-dir."
+    print("Continue mode activated. Ignore all options other than -o/--out-dir.", file=sys.stderr)
 
     with open(opt.out_dir + "opts.txt", "r") as f:
         argv = []
         for line in f:
             argv.append(line.strip())
-        print >> sys.stderr, "Continue with options: " + " ".join(argv)
+        print("Continue with options: " + " ".join(argv), file=sys.stderr)
         opt = Options()
         opt.continue_mode = 1 # avoid dead loop
         parse_opt(argv)
@@ -315,27 +317,27 @@ def prepare_continue():
                 if len(a) == 2 and a[1] == "done":
                     opt.last_cp = int(a[0])
         cpf.close()
-    print >> sys.stderr, "Continue from check point " + str(opt.last_cp) 
+    print("Continue from check point " + str(opt.last_cp), file=sys.stderr) 
 
 def check_bin():
     if not os.path.exists(opt.bin_dir + "megahit_assemble"):
-        print >> sys.stderr, megahit_version_str + '\n' + "Cannot find sub-program \"megahit_assemble\", please recompile."
+        print(megahit_version_str + '\n' + "Cannot find sub-program \"megahit_assemble\", please recompile.", file=sys.stderr)
         exit(1)
     if not os.path.exists(opt.bin_dir + "megahit_iter_k61"):
-        print >> sys.stderr, megahit_version_str + '\n' + "Cannot find sub-program \"megahit_iter_k61\", please recompile."
+        print(megahit_version_str + '\n' + "Cannot find sub-program \"megahit_iter_k61\", please recompile.", file=sys.stderr)
         exit(1)
     if not os.path.exists(opt.bin_dir + "megahit_iter_k92"):
-        print >> sys.stderr, megahit_version_str + '\n' + "Cannot find sub-program \"megahit_iter_k92\", please recompile."
+        print(megahit_version_str + '\n' + "Cannot find sub-program \"megahit_iter_k92\", please recompile.", file=sys.stderr)
         exit(1)
     if not os.path.exists(opt.bin_dir + "megahit_iter_k124"):
-        print >> sys.stderr, megahit_version_str + '\n' + "Cannot find sub-program \"megahit_iter_k124\", please recompile."
+        print(megahit_version_str + '\n' + "Cannot find sub-program \"megahit_iter_k124\", please recompile.", file=sys.stderr)
         exit(1)
 
 def check_builder():
     if not os.path.exists(opt.bin_dir + opt.builder):
-        print >> sys.stderr, megahit_version_str + '\n' + "Cannot find sub-program \"%s\", please recompile." % opt.builder
+        print(megahit_version_str + '\n' + "Cannot find sub-program \"%s\", please recompile." % opt.builder, file=sys.stderr)
         if opt.cpu_only == 0:
-            print >> sys.stderr, "Or if you want to use the CPU-only version, please run MEGAHIT with \"--cpu-only\""
+            print("Or if you want to use the CPU-only version, please run MEGAHIT with \"--cpu-only\"", file=sys.stderr)
         exit(1)
 
 def graph_prefix(kmer_k):
@@ -373,7 +375,7 @@ def delete_temp_files(kmer_k):
 
 def write_cp(cp):
     cpf = open(opt.temp_dir + "cp.txt", "a")
-    print >> cpf, "\n" + str(cp) + "\t" + "done";
+    print("\n" + str(cp) + "\t" + "done", file=cpf);
     cpf.flush()
     cpf.close()
 
@@ -401,9 +403,9 @@ def build_first_graph():
         try:
             log_file = open(log_file_name(), "a")
             start_time = datetime.now()
-            print >> log_file, "%s" % (" ").join(count_cmd)
-            print >> sys.stderr, "[%s] Extracting solid (k+1)-mers for k = %d" % (start_time.strftime("%c"), opt.k_min)
-            print >> log_file, "[%s] Extracting solid (k+1)-mers for k = %d" % (start_time.strftime("%c"), opt.k_min)
+            print("%s" % (" ").join(count_cmd), file=log_file)
+            print("[%s] Extracting solid (k+1)-mers for k = %d" % (start_time.strftime("%c"), opt.k_min), file=sys.stderr)
+            print("[%s] Extracting solid (k+1)-mers for k = %d" % (start_time.strftime("%c"), opt.k_min), file=log_file)
             log_file.flush()
             if opt.read_file == "":
                 input_thread = subprocess.Popen(opt.input_cmd, shell = True, stdout = subprocess.PIPE)
@@ -413,14 +415,14 @@ def build_first_graph():
             else:
                 ret_code = subprocess.call(count_cmd, stdout = log_file)
             if ret_code != 0:
-                print >> sys.stderr, "Error occurs when running \"builder count\""
-                print >> sys.stderr, "[Exit code %d] " % ret_code
+                print("Error occurs when running \"builder count\"", file=sys.stderr)
+                print("[Exit code %d] " % ret_code, file=sys.stderr)
                 exit(ret_code)
             log_file.close()
 
-        except OSError, o:
+        except OSError as o:
             if o.errno == errno.ENOTDIR or o.errno == errno.ENOENT:
-                print >> sys.stderr, "Error: sub-program builder not found, please recompile MEGAHIT"
+                print("Error: sub-program builder not found, please recompile MEGAHIT", file=sys.stderr)
             exit(1)
 
     write_cp(cp)
@@ -448,19 +450,19 @@ def build_graph(kmer_k, num_edge_files):
         try:
             log_file = open(log_file_name(), "a")
             start_time = datetime.now()
-            print >> log_file, "%s" % (" ").join(build_cmd)
-            print >> sys.stderr, "[%s] Building graph for k = %d" % (start_time.strftime("%c"), kmer_k)
-            print >> log_file, "[%s] Building graph for k = %d" % (start_time.strftime("%c"), kmer_k)
+            print("%s" % (" ").join(build_cmd), file=log_file)
+            print("[%s] Building graph for k = %d" % (start_time.strftime("%c"), kmer_k), file=sys.stderr)
+            print("[%s] Building graph for k = %d" % (start_time.strftime("%c"), kmer_k), file=log_file)
             log_file.flush()
             ret_code = subprocess.call(build_cmd, stdout = log_file)
             if ret_code != 0:
-                print >> sys.stderr, "Error occurs when running \"builder build\" for k = %d" % kmer_k
-                print >> sys.stderr, "[Exit code %d]" % ret_code
+                print("Error occurs when running \"builder build\" for k = %d" % kmer_k, file=sys.stderr)
+                print("[Exit code %d]" % ret_code, file=sys.stderr)
                 exit(ret_code)
             log_file.close()
-        except OSError, o:
+        except OSError as o:
             if o.errno == errno.ENOTDIR or o.errno == errno.ENOENT:
-                print >> sys.stderr, "Error: sub-program builder not found, please recompile MEGAHIT"
+                print("Error: sub-program builder not found, please recompile MEGAHIT", file=sys.stderr)
             exit(1) 
 
     write_cp(cp)
@@ -514,9 +516,9 @@ def iterate(cur_k, step):
         try:
             log_file = open(log_file_name(), "a")
             start_time = datetime.now()
-            print >> log_file, "%s" % (" ").join(iterate_cmd)
-            print >> sys.stderr, "[%s] Extracting iterative edges from k = %d to %d" % (start_time.strftime("%c"), cur_k, next_k)
-            print >> log_file, "[%s] Extracting iterative edges from k = %d to %d" % (start_time.strftime("%c"), cur_k, next_k)
+            print("%s" % (" ").join(iterate_cmd), file=log_file)
+            print("[%s] Extracting iterative edges from k = %d to %d" % (start_time.strftime("%c"), cur_k, next_k), file=sys.stderr)
+            print("[%s] Extracting iterative edges from k = %d to %d" % (start_time.strftime("%c"), cur_k, next_k), file=log_file)
             log_file.flush()
 
             ret_code = 0
@@ -528,15 +530,15 @@ def iterate(cur_k, step):
             else:
                 ret_code = subprocess.call(iterate_cmd, stdout = log_file)
             if ret_code != 0:
-                print >> sys.stderr, "Error occurs when running iterator for k = %d to k = %d " % (cur_k, next_k)
-                print >> sys.stderr, "[Exit code %d]" % ret_code
+                print("Error occurs when running iterator for k = %d to k = %d " % (cur_k, next_k), file=sys.stderr)
+                print("[Exit code %d]" % ret_code, file=sys.stderr)
                 exit(ret_code)
 
             log_file.close()
 
-        except OSError, o:
+        except OSError as o:
             if o.errno == errno.ENOTDIR or o.errno == errno.ENOENT:
-                print >> sys.stderr, "Error: sub-program iterater_edge not found, please recompile MEGAHIT"
+                print("Error: sub-program iterater_edge not found, please recompile MEGAHIT", file=sys.stderr)
             exit(1)
     write_cp(cp)
     cp = cp + 1
@@ -563,21 +565,21 @@ def assemble(cur_k):
         try:
             log_file = open(log_file_name(), "a")
             start_time = datetime.now()
-            print >> log_file, "%s" % (" ").join(assembly_cmd)
-            print >> sys.stderr, "[%s] Assembling contigs from SdBG for k = %d" % (start_time.strftime("%c"), cur_k)
-            print >> log_file, "[%s] Assembling contigs from SdBG for k = %d" % (start_time.strftime("%c"), cur_k)
+            print("%s" % (" ").join(assembly_cmd), file=log_file)
+            print("[%s] Assembling contigs from SdBG for k = %d" % (start_time.strftime("%c"), cur_k), file=sys.stderr)
+            print("[%s] Assembling contigs from SdBG for k = %d" % (start_time.strftime("%c"), cur_k), file=log_file)
             log_file.flush()
             ret_code = subprocess.call(assembly_cmd, stdout = log_file)
             if ret_code != 0:
-                print >> sys.stderr, "Error occurs when assembling contigs for k = %d" % cur_k
-                print >> sys.stderr, "[Exit code %d]" % ret_code
+                print("Error occurs when assembling contigs for k = %d" % cur_k, file=sys.stderr)
+                print("[Exit code %d]" % ret_code, file=sys.stderr)
                 exit(ret_code)
 
             log_file.close()
             
-        except OSError, o:
+        except OSError as o:
             if o.errno == errno.ENOTDIR or o.errno == errno.ENOENT:
-                print >> sys.stderr, "Error: sub-program assembler not found, please recompile MEGAHIT"
+                print("Error: sub-program assembler not found, please recompile MEGAHIT", file=sys.stderr)
             exit(1)
     write_cp(cp)
     cp = cp + 1
@@ -585,8 +587,8 @@ def assemble(cur_k):
 def merge_final():
     log_file = open(log_file_name(), "a")
     start_time = datetime.now()
-    print >> sys.stderr, "[%s] Merging to output final contigs." % (start_time.strftime("%c"))
-    print >> log_file, "[%s] Merging to output final contigs.." % (start_time.strftime("%c"))
+    print("[%s] Merging to output final contigs." % (start_time.strftime("%c")), file=sys.stderr)
+    print("[%s] Merging to output final contigs.." % (start_time.strftime("%c")), file=log_file)
     os.system("cat " + opt.temp_dir + "*.final.contigs.fa > " + opt.out_dir + "final.contigs.fa")
     log_file.flush()
     log_file.close()
@@ -602,8 +604,8 @@ def main(argv = None):
         check_builder()
 
         start_time = datetime.now()  
-        print >> sys.stderr, megahit_version_str
-        print >> sys.stderr, "[%s] Start assembly. Number of CPU threads %d." % (start_time.strftime("%c"), opt.num_cpu_threads)
+        print(megahit_version_str, file=sys.stderr)
+        print("[%s] Start assembly. Number of CPU threads %d." % (start_time.strftime("%c"), opt.num_cpu_threads), file=sys.stderr)
 
         make_out_dir()
         if opt.continue_mode != True:
@@ -639,14 +641,14 @@ def main(argv = None):
 
         log_file = open(log_file_name(), "a")
         start_time = datetime.now()
-        print >> sys.stderr, "[%s] ALL DONE." % (start_time.strftime("%c"))
-        print >> log_file, "[%s] ALL DONE." % (start_time.strftime("%c"))
+        print("[%s] ALL DONE." % (start_time.strftime("%c")), file=sys.stderr)
+        print("[%s] ALL DONE." % (start_time.strftime("%c")), file=log_file)
         log_file.flush()
         log_file.close()
         open(opt.out_dir + "done", "w").close()
 
-    except Usage, err:
-        print >> sys.stderr, sys.argv[0].split("/")[-1] + ": " + str(err.msg)
+    except Usage as err:
+        print(sys.argv[0].split("/")[-1] + ": " + str(err.msg), file=sys.stderr)
         return 2
 
 if __name__ == "__main__":


### PR DESCRIPTION
Dear authors,

We faced some compatibility issues with `python` version 2 and 3 within our cluster environment. We made some changes to the `megahit` script to deal with this. We first converted the code using `2to3` and then some small edits. It is now `python3` syntax and can be back ported to `python2`. I hope the script is more robust now to `python` version changes.

I will be happy to provide you with the logs of runs on both versions after editing upon request.
-Shaman-