### PR TITLE
quote filenames before passing to shell

### DIFF
--- a/megahit
+++ b/megahit
@@ -577,11 +577,11 @@ def write_cp():
 
 def inpipe_cmd(file_name):
     if file_name.endswith('.gz'):
-        return 'gzip -cd ' + file_name
+        return "gzip -cd '{}'".format(file_name)
     elif file_name.endswith('.bz2'):
-        return 'bzip2 -cd ' + file_name
+        return "bzip2 -cd '{}'".format(file_name)
     else:
-        return "cat " + file_name
+        return "cat '{}'".format(file_name)
 
 def write_lib():
     global opt

--- a/megahit
+++ b/megahit
@@ -577,11 +577,11 @@ def write_cp():
 
 def inpipe_cmd(file_name):
     if file_name.endswith('.gz'):
-        return "gzip -cd '{}'".format(file_name)
+        return "gzip -cd '" + file_name + "'"
     elif file_name.endswith('.bz2'):
-        return "bzip2 -cd '{}'".format(file_name)
+        return "bzip2 -cd '" + file_name + "'"
     else:
-        return "cat '{}'".format(file_name)
+        return "cat '" +  file_name + "'"
 
 def write_lib():
     global opt


### PR DESCRIPTION
Without the single quotes around the filenames, filenames containing spaces will confuse shell. fixes #89

This is a "minimally invasive" patch. Using shell is inherently insecure, there are still filenames that will break this (e.g. containing a single-quote character).