### PR TITLE
Minimum changes to compile on graviton2 (no bmi2, no popcnt)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,8 @@ add_executable(megahit_core_popcnt ${OTHER_SOURCE} ${ASMBL_SOURCE} ${IDBA_SOURCE
         ${CX1_SOURCE} ${TOOLKIT_SOURCE})
 add_executable(megahit_core_no_hw_accel ${OTHER_SOURCE} ${ASMBL_SOURCE} ${IDBA_SOURCE} ${SDBG_SOURCE} ${LCASM_SOURCE}
         ${SEQ_SOURCE} ${CX1_SOURCE} ${TOOLKIT_SOURCE})
-set_target_properties(megahit_core PROPERTIES COMPILE_FLAGS "-mbmi2 -DUSE_BMI2 -mpopcnt")
-set_target_properties(megahit_core_popcnt PROPERTIES COMPILE_FLAGS "-mpopcnt")
+#set_target_properties(megahit_core PROPERTIES COMPILE_FLAGS "-mbmi2 -DUSE_BMI2 -mpopcnt")
+#set_target_properties(megahit_core_popcnt PROPERTIES COMPILE_FLAGS "-mpopcnt")
 
 if (STATIC_BUILD)
     # TODO dirty

--- a/src/kmlib/kmrns.h
+++ b/src/kmlib/kmrns.h
@@ -8,7 +8,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <x86intrin.h>
 #include <vector>
 
 namespace kmlib {

--- a/src/utils/cpu_dispatch.h
+++ b/src/utils/cpu_dispatch.h
@@ -5,32 +5,7 @@
 #ifndef MEGAHIT_CPU_DISPATCH_H
 #define MEGAHIT_CPU_DISPATCH_H
 
-inline bool HasPopcnt() {
-  unsigned eax, ebx, ecx, edx;
-#ifdef _MSC_VER
-  int cpuid[4];
-  __cpuid(cpuid, 1);
-  eax = cpuid[0], ebx = cpuid[1], ecx = cpuid[2], edx = cpuid[3];
-#else
-  asm volatile("cpuid\n\t"
-               : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx)
-               : "0"(1));
-#endif
-  return ecx >> 23U & 1U;
-}
-
-inline bool HasBmi2() {
-  unsigned eax, ebx, ecx, edx;
-#ifdef _MSC_VER
-  int cpuid[4];
-  __cpuidex(cpuid, 7, 0);
-  eax = cpuid[0], ebx = cpuid[1], ecx = cpuid[2], edx = cpuid[3];
-#else
-  asm volatile("cpuid\n\t"
-               : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx)
-               : "0"(7), "2"(0));
-#endif
-  return ebx >> 8U & 1U;
-}
+inline bool HasPopcnt() { return false; }
+inline bool HasBmi2() { return false; }
 
 #endif  // MEGAHIT_CPU_DISPATCH_H


### PR DESCRIPTION
Disable bmi2 and popcount. Since x86intrin.h is removed from src/kmlib/kmrns.h this PR would only work for aarch64. 