### PR TITLE
Adds an interactive Jupyter notebook example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ To see the full manual, run `megahit` without parameters or with `-h`.
 
 Also, our [wiki](https://github.com/voutcn/megahit/wiki) may be helpful.
 
+### Examples
+
+There is an example of a real assembly on this [wiki page](https://github.com/voutcn/megahit/wiki/An-example-of-real-assembly) 
+and its corresponding [interactive Jupyter notebook](https://biotutorials.org/megahit).
+
 Publications
 ------------
 


### PR DESCRIPTION
I wrote a notebook based off the [real assembly wiki page](https://github.com/voutcn/megahit/wiki/An-example-of-real-assembly) to help our collaborators get started with MEGAHIT, and thought it might be helpful for others. This PR adds a link to [an interactive Jupyter notebook](https://biotutorials.org/megahit) in the README; I'm not sure if that's the best place for this notebook.

To make this work, I built a small service that spins up a unique JupyterLab session for each user and uses our HPC servers for the compute-intensive parts. It's free, can run the real example from the MEGAHIT wiki page in around 20 minutes, and my hope is that it helps researchers get started with MEGAHIT more quickly.

I'm happy to make any changes to the notebook as needed. Here's a short video of the notebook spawning in action:


https://user-images.githubusercontent.com/10551613/218197716-7530c5e6-d8bb-456c-b672-7254cbb3cc68.mov

