### PR TITLE
Fix `gcc-13` build failure (missing `<cstdint>` include)

### DIFF
--- a/src/localasm/local_assemble.h
+++ b/src/localasm/local_assemble.h
@@ -22,6 +22,7 @@
 #ifndef LOCAL_ASSEMBLER_H
 #define LOCAL_ASSEMBLER_H
 
+#include <cstdint>
 #include <string>
 
 struct LocalAsmOption {


### PR DESCRIPTION
Without the change build fails on `gcc-13` as:

    In file included from /build/source/src/main_local_assemble.cpp:27:
    /build/source/src/localasm/local_assemble.h:31:3: error: 'uint32_t' does not name a type
       31 |   uint32_t kmin{11};
          |   ^~~~~~~~
    /build/source/src/localasm/local_assemble.h:1:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
      +++ |+#include <cstdint>