### PR TITLE
Add support for non-x86_64 architectures (e.g. Linux ARM64)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,12 @@ add_executable(megahit_core_popcnt ${OTHER_SOURCE} ${ASMBL_SOURCE} ${IDBA_SOURCE
         ${CX1_SOURCE} ${TOOLKIT_SOURCE})
 add_executable(megahit_core_no_hw_accel ${OTHER_SOURCE} ${ASMBL_SOURCE} ${IDBA_SOURCE} ${SDBG_SOURCE} ${LCASM_SOURCE}
         ${SEQ_SOURCE} ${CX1_SOURCE} ${TOOLKIT_SOURCE})
-set_target_properties(megahit_core PROPERTIES COMPILE_FLAGS "-mbmi2 -DUSE_BMI2 -mpopcnt")
-set_target_properties(megahit_core_popcnt PROPERTIES COMPILE_FLAGS "-mpopcnt")
+
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(amd64)|(AMD64)")
+    set_target_properties(megahit_core PROPERTIES COMPILE_FLAGS "-mbmi2 -DUSE_BMI2 -mpopcnt")
+    set_target_properties(megahit_core_popcnt PROPERTIES COMPILE_FLAGS "-mpopcnt")
+endif ()
+
 
 if (STATIC_BUILD)
     # TODO dirty

--- a/src/kmlib/kmrns.h
+++ b/src/kmlib/kmrns.h
@@ -8,7 +8,9 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(__x86_64__)
 #include <x86intrin.h>
+#endif
 #include <vector>
 
 namespace kmlib {

--- a/src/utils/cpu_dispatch.h
+++ b/src/utils/cpu_dispatch.h
@@ -5,6 +5,7 @@
 #ifndef MEGAHIT_CPU_DISPATCH_H
 #define MEGAHIT_CPU_DISPATCH_H
 
+#if defined(__x86_64__)
 inline bool HasPopcnt() {
   unsigned eax, ebx, ecx, edx;
 #ifdef _MSC_VER
@@ -32,5 +33,10 @@ inline bool HasBmi2() {
 #endif
   return ebx >> 8U & 1U;
 }
+#else
+inline bool HasPopcnt() { return false; }
+inline bool HasBmi2() { return false; }
+#endif
+
 
 #endif  // MEGAHIT_CPU_DISPATCH_H


### PR DESCRIPTION
Fixes https://github.com/voutcn/megahit/issues/320 
Based on: https://github.com/voutcn/megahit/pull/329

Preserves the x86_64 specifics when building on x86_64 machine