### PR TITLE
docs: fix example Docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cd MEGAHIT-1.2.9-Linux-x86_64-static/bin/
 ``` sh
 # in the directory with the input reads
 docker run -v $(pwd):/workspace -w /workspace --user $(id -u):$(id -g) vout/megahit \
-  megahit -1 MY_PE_READ_1.fq.gz -2 MY_PE_READ_2.fq.gz -o MY_OUTPUT_DIR
+  -1 MY_PE_READ_1.fq.gz -2 MY_PE_READ_2.fq.gz -o MY_OUTPUT_DIR
 ```
 
 ### Building from source


### PR DESCRIPTION
The [README's Docker snippet](https://github.com/voutcn/megahit/blob/master/README.md?plain=1#L37-L38) was passing "megahit" twice:

```bash
  docker run ... vout/megahit \
    megahit -1 reads_R1.fq -2 reads_R2.fq -o out
```

Because the image's ENTRYPOINT already invokes the binary, the extra "megahit" made CLI parser show the help menu. Users could not run the containerized assembler "out of the box."

This change drops the second "megahit" so that flags are correctly forwarded to the default entrypoint:

```bash
  docker run ... vout/megahit \
    -1 reads_R1.fq -2 reads_R2.fq -o out
```

Now the example works as intended and users can launch MEGAHIT via Docker without confusion.